### PR TITLE
Pass string as message

### DIFF
--- a/lib/omniture_client/client.rb
+++ b/lib/omniture_client/client.rb
@@ -126,9 +126,9 @@ module OmnitureClient
       begin
         parsed = JSON.parse(response.body)
         if parsed["error"] == "report_not_ready"
-          raise OmnitureClient::Exceptions::ReportNotReady.new(parsed)
+          raise OmnitureClient::Exceptions::ReportNotReady.new(response.body)
         else
-          raise OmnitureClient::Exceptions::RequestInvalid.new(parsed)
+          raise OmnitureClient::Exceptions::RequestInvalid.new(response.body)
         end
       rescue JSON::ParserError => e
         if response.code == 404

--- a/lib/omniture_client/version.rb
+++ b/lib/omniture_client/version.rb
@@ -1,3 +1,3 @@
 module OmnitureClient
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
When raising errors, sometimes a ruby hash was passed, sometimes a string. 
This PR changes that behaviour to always pass a string, in order to have a more clear 
API.
