### PR TITLE
Drop logger gem dependency

### DIFF
--- a/lib/omniture_client/version.rb
+++ b/lib/omniture_client/version.rb
@@ -1,3 +1,3 @@
 module OmnitureClient
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/omniture_client.gemspec
+++ b/omniture_client.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
 
   spec.add_runtime_dependency("httparty")
-  spec.add_runtime_dependency("json")  
-  spec.add_runtime_dependency("logger")  
+  spec.add_runtime_dependency("json")
 end


### PR DESCRIPTION
Since the [issue with logger v1.2.8](https://github.com/nahi/logger/issues/3) its better to drop the direct dependency of this gem, keeping in mind that its also included in ruby by default.

This will now resolve issues with `bundle install` and `builds`.